### PR TITLE
🐛 added "abort guest session"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dmf/sw6-manu-theme",
     "description": "Manu Theme",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "type": "shopware-platform-plugin",
     "authors": [
         {

--- a/src/Resources/views/storefront/page/account/sidebar.html.twig
+++ b/src/Resources/views/storefront/page/account/sidebar.html.twig
@@ -85,6 +85,17 @@
                             {% endblock %}
                         {% endblock %}
                     </div>
+                {% else %}
+                    <div class="card-footer account-aside-footer account-guest-abort">
+                        {% block page_account_sidebar_guest_abort %}
+                            <a href="{{ path('frontend.account.logout.page') }}"
+                               data-account-guest-abort-button="true"
+                               class="btn btn-link account-aside-btn">
+                                {% sw_icon 'log-out' %}
+                                {{ "account.guestAbort"|trans|sw_sanitize }}
+                            </a>
+                        {% endblock %}
+                    </div>
                 {% endif %}
             {% endblock %}
             


### PR DESCRIPTION
 If you leave the checkout the header menu was broken. The Shopware 6 default theme has a button to abort the guest session, this adds the button. Without the fix an empty user menu is shown.